### PR TITLE
lfsr.v initial mask assignments refactor

### DIFF
--- a/rtl/lfsr.v
+++ b/rtl/lfsr.v
@@ -208,7 +208,7 @@ localparam integer MAX_WIDTH = LFSR_WIDTH > DATA_WIDTH ? LFSR_WIDTH : DATA_WIDTH
 
 integer i, j;
 
-function automatic [4*MAX_WIDTH*MAX_WIDTH:0] generate_masks;
+function automatic [4*MAX_WIDTH*MAX_WIDTH-1:0] generate_masks;
     input integer dummy;
     integer i, j;
     reg [LFSR_WIDTH-1:0] state_val;
@@ -359,37 +359,40 @@ begin
             output_mask_data_i[i] = data_val;
         end
     end
-
     for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-        generate_masks[0 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = lfsr_mask_state_i[i];
-        generate_masks[1 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = lfsr_mask_data_i[i];
+        generate_masks[MAX_WIDTH * (0 * MAX_WIDTH + i) +: MAX_WIDTH] = lfsr_mask_state_i[i];
+        generate_masks[MAX_WIDTH * (1 * MAX_WIDTH + i) +: MAX_WIDTH] = lfsr_mask_data_i[i];
     end
 
     for (i = 0; i < DATA_WIDTH; i = i + 1) begin
-        generate_masks[2 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = output_mask_state_i[i];
-        generate_masks[3 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = output_mask_data_i[i];
+        generate_masks[MAX_WIDTH * (2 * MAX_WIDTH + i) +: MAX_WIDTH] = output_mask_state_i[i];
+        generate_masks[MAX_WIDTH * (3 * MAX_WIDTH + i) +: MAX_WIDTH] = output_mask_data_i[i];
     end
 end
 endfunction
 
-reg [4*MAX_WIDTH*MAX_WIDTH:0] generated_masks = generate_masks(1);
+reg [4*MAX_WIDTH*MAX_WIDTH-1:0] generated_masks = generate_masks(1);
+
+reg [LFSR_WIDTH-1:0] lfsr_mask_state_c[LFSR_WIDTH-1:0];
+reg [DATA_WIDTH-1:0] lfsr_mask_data_c[LFSR_WIDTH-1:0];
+reg [LFSR_WIDTH-1:0] output_mask_state_c[DATA_WIDTH-1:0];
+reg [DATA_WIDTH-1:0] output_mask_data_c[DATA_WIDTH-1:0];
+
 
 initial begin
     for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-        lfsr_mask_state[i] = generated_masks[0 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
-        lfsr_mask_data[i] = generated_masks[1 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+        lfsr_mask_state[i] = generated_masks[MAX_WIDTH * (0 * MAX_WIDTH + i) +: MAX_WIDTH];
+        lfsr_mask_data[i]  = generated_masks[MAX_WIDTH * (1 * MAX_WIDTH + i) +: MAX_WIDTH];
     end
 
-    for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-        output_mask_data[i] = generated_masks[3 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
-        output_mask_state[i] = generated_masks[2 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+    for (i = 0; i < DATA_WIDTH; i = i + 1) begin
+        output_mask_state[i] = generated_masks[MAX_WIDTH * (2 * MAX_WIDTH + i) +: MAX_WIDTH];
+        output_mask_data[i]  = generated_masks[MAX_WIDTH * (3 * MAX_WIDTH + i) +: MAX_WIDTH];
     end
-
     // for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
     //     $display("%d %b %b", i, lfsr_mask_state[i], lfsr_mask_data[i]);
     // end
 end
-
 
 
 // synthesis translate_off

--- a/rtl/lfsr.v
+++ b/rtl/lfsr.v
@@ -203,24 +203,35 @@ reg [DATA_WIDTH-1:0] lfsr_mask_data[LFSR_WIDTH-1:0];
 reg [LFSR_WIDTH-1:0] output_mask_state[DATA_WIDTH-1:0];
 reg [DATA_WIDTH-1:0] output_mask_data[DATA_WIDTH-1:0];
 
-reg [LFSR_WIDTH-1:0] state_val = 0;
-reg [DATA_WIDTH-1:0] data_val = 0;
 
-integer i, j, k;
+localparam integer MAX_WIDTH = LFSR_WIDTH > DATA_WIDTH ? LFSR_WIDTH : DATA_WIDTH;
 
-initial begin
+integer i, j;
+
+function automatic [4*MAX_WIDTH*MAX_WIDTH:0] generate_masks;
+    input integer dummy;
+    integer i, j;
+    reg [LFSR_WIDTH-1:0] state_val;
+    reg [DATA_WIDTH-1:0] data_val;
+    reg [LFSR_WIDTH-1:0] lfsr_mask_state_i[LFSR_WIDTH-1:0];
+    reg [DATA_WIDTH-1:0] lfsr_mask_data_i[LFSR_WIDTH-1:0];
+    reg [LFSR_WIDTH-1:0] output_mask_state_i[DATA_WIDTH-1:0];
+    reg [DATA_WIDTH-1:0] output_mask_data_i[DATA_WIDTH-1:0];
+begin
+    state_val = 0;
+    data_val = 0;
     // init bit masks
     for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-        lfsr_mask_state[i] = {LFSR_WIDTH{1'b0}};
-        lfsr_mask_state[i][i] = 1'b1;
-        lfsr_mask_data[i] = {DATA_WIDTH{1'b0}};
+        lfsr_mask_state_i[i] = {LFSR_WIDTH{1'b0}};
+        lfsr_mask_state_i[i][i] = 1'b1;
+        lfsr_mask_data_i[i] = {DATA_WIDTH{1'b0}};
     end
     for (i = 0; i < DATA_WIDTH; i = i + 1) begin
-        output_mask_state[i] = {LFSR_WIDTH{1'b0}};
+        output_mask_state_i[i] = {LFSR_WIDTH{1'b0}};
         if (i < LFSR_WIDTH) begin
-            output_mask_state[i][i] = 1'b1;
+            output_mask_state_i[i][i] = 1'b1;
         end
-        output_mask_data[i] = {DATA_WIDTH{1'b0}};
+        output_mask_data_i[i] = {DATA_WIDTH{1'b0}};
     end
 
     // simulate shift register
@@ -229,70 +240,70 @@ initial begin
         for (i = DATA_WIDTH-1; i >= 0; i = i - 1) begin
             // determine shift in value
             // current value in last FF, XOR with input data bit (MSB first)
-            state_val = lfsr_mask_state[LFSR_WIDTH-1];
-            data_val = lfsr_mask_data[LFSR_WIDTH-1];
+            state_val = lfsr_mask_state_i[LFSR_WIDTH-1];
+            data_val = lfsr_mask_data_i[LFSR_WIDTH-1];
             data_val = data_val ^ (1 << i);
 
             // add XOR inputs from correct indicies
             for (j = 1; j < LFSR_WIDTH; j = j + 1) begin
                 if (LFSR_POLY & (1 << j)) begin
-                    state_val = lfsr_mask_state[j-1] ^ state_val;
-                    data_val = lfsr_mask_data[j-1] ^ data_val;
+                    state_val = lfsr_mask_state_i[j-1] ^ state_val;
+                    data_val = lfsr_mask_data_i[j-1] ^ data_val;
                 end
             end
 
             // shift
             for (j = LFSR_WIDTH-1; j > 0; j = j - 1) begin
-                lfsr_mask_state[j] = lfsr_mask_state[j-1];
-                lfsr_mask_data[j] = lfsr_mask_data[j-1];
+                lfsr_mask_state_i[j] = lfsr_mask_state_i[j-1];
+                lfsr_mask_data_i[j] = lfsr_mask_data_i[j-1];
             end
             for (j = DATA_WIDTH-1; j > 0; j = j - 1) begin
-                output_mask_state[j] = output_mask_state[j-1];
-                output_mask_data[j] = output_mask_data[j-1];
+                output_mask_state_i[j] = output_mask_state_i[j-1];
+                output_mask_data_i[j] = output_mask_data_i[j-1];
             end
-            output_mask_state[0] = state_val;
-            output_mask_data[0] = data_val;
+            output_mask_state_i[0] = state_val;
+            output_mask_data_i[0] = data_val;
             if (LFSR_FEED_FORWARD) begin
                 // only shift in new input data
                 state_val = {LFSR_WIDTH{1'b0}};
                 data_val = 1 << i;
             end
-            lfsr_mask_state[0] = state_val;
-            lfsr_mask_data[0] = data_val;
+            lfsr_mask_state_i[0] = state_val;
+            lfsr_mask_data_i[0] = data_val;
         end
     end else if (LFSR_CONFIG == "GALOIS") begin
         // Galois configuration
         for (i = DATA_WIDTH-1; i >= 0; i = i - 1) begin
             // determine shift in value
             // current value in last FF, XOR with input data bit (MSB first)
-            state_val = lfsr_mask_state[LFSR_WIDTH-1];
-            data_val = lfsr_mask_data[LFSR_WIDTH-1];
+            state_val = lfsr_mask_state_i[LFSR_WIDTH-1];
+            data_val = lfsr_mask_data_i[LFSR_WIDTH-1];
             data_val = data_val ^ (1 << i);
 
             // shift
             for (j = LFSR_WIDTH-1; j > 0; j = j - 1) begin
-                lfsr_mask_state[j] = lfsr_mask_state[j-1];
-                lfsr_mask_data[j] = lfsr_mask_data[j-1];
+                lfsr_mask_state_i[j] = lfsr_mask_state_i[j-1];
+                lfsr_mask_data_i[j] = lfsr_mask_data_i[j-1];
             end
             for (j = DATA_WIDTH-1; j > 0; j = j - 1) begin
-                output_mask_state[j] = output_mask_state[j-1];
-                output_mask_data[j] = output_mask_data[j-1];
+                output_mask_state_i[j] = output_mask_state_i[j-1];
+                output_mask_data_i[j] = output_mask_data_i[j-1];
             end
-            output_mask_state[0] = state_val;
-            output_mask_data[0] = data_val;
+            output_mask_state_i[0] = state_val;
+            output_mask_data_i[0] = data_val;
             if (LFSR_FEED_FORWARD) begin
                 // only shift in new input data
                 state_val = {LFSR_WIDTH{1'b0}};
                 data_val = 1 << i;
             end
-            lfsr_mask_state[0] = state_val;
-            lfsr_mask_data[0] = data_val;
+            lfsr_mask_state_i[0] = state_val;
+            lfsr_mask_data_i[0] = data_val;
 
             // add XOR inputs at correct indicies
             for (j = 1; j < LFSR_WIDTH; j = j + 1) begin
                 if (LFSR_POLY & (1 << j)) begin
-                    lfsr_mask_state[j] = lfsr_mask_state[j] ^ state_val;
-                    lfsr_mask_data[j] = lfsr_mask_data[j] ^ data_val;
+                    lfsr_mask_state_i[j] = lfsr_mask_state_i[j] ^ state_val;
+                    lfsr_mask_data_i[j] = lfsr_mask_data_i[j] ^ data_val;
                 end
             end
         end
@@ -305,54 +316,81 @@ initial begin
     if (REVERSE) begin
         // reverse order
         for (i = 0; i < LFSR_WIDTH/2; i = i + 1) begin
-            state_val = lfsr_mask_state[i];
-            data_val = lfsr_mask_data[i];
-            lfsr_mask_state[i] = lfsr_mask_state[LFSR_WIDTH-i-1];
-            lfsr_mask_data[i] = lfsr_mask_data[LFSR_WIDTH-i-1];
-            lfsr_mask_state[LFSR_WIDTH-i-1] = state_val;
-            lfsr_mask_data[LFSR_WIDTH-i-1] = data_val;
+            state_val = lfsr_mask_state_i[i];
+            data_val = lfsr_mask_data_i[i];
+            lfsr_mask_state_i[i] = lfsr_mask_state_i[LFSR_WIDTH-i-1];
+            lfsr_mask_data_i[i] = lfsr_mask_data_i[LFSR_WIDTH-i-1];
+            lfsr_mask_state_i[LFSR_WIDTH-i-1] = state_val;
+            lfsr_mask_data_i[LFSR_WIDTH-i-1] = data_val;
         end
         for (i = 0; i < DATA_WIDTH/2; i = i + 1) begin
-            state_val = output_mask_state[i];
-            data_val = output_mask_data[i];
-            output_mask_state[i] = output_mask_state[DATA_WIDTH-i-1];
-            output_mask_data[i] = output_mask_data[DATA_WIDTH-i-1];
-            output_mask_state[DATA_WIDTH-i-1] = state_val;
-            output_mask_data[DATA_WIDTH-i-1] = data_val;
+            state_val = output_mask_state_i[i];
+            data_val = output_mask_data_i[i];
+            output_mask_state_i[i] = output_mask_state_i[DATA_WIDTH-i-1];
+            output_mask_data_i[i] = output_mask_data_i[DATA_WIDTH-i-1];
+            output_mask_state_i[DATA_WIDTH-i-1] = state_val;
+            output_mask_data_i[DATA_WIDTH-i-1] = data_val;
         end
         // reverse bits
         for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
             state_val = 0;
             for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
-                state_val[j] = lfsr_mask_state[i][LFSR_WIDTH-j-1];
+                state_val[j] = lfsr_mask_state_i[i][LFSR_WIDTH-j-1];
             end
-            lfsr_mask_state[i] = state_val;
+            lfsr_mask_state_i[i] = state_val;
 
             data_val = 0;
             for (j = 0; j < DATA_WIDTH; j = j + 1) begin
-                data_val[j] = lfsr_mask_data[i][DATA_WIDTH-j-1];
+                data_val[j] = lfsr_mask_data_i[i][DATA_WIDTH-j-1];
             end
-            lfsr_mask_data[i] = data_val;
+            lfsr_mask_data_i[i] = data_val;
         end
         for (i = 0; i < DATA_WIDTH; i = i + 1) begin
             state_val = 0;
             for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
-                state_val[j] = output_mask_state[i][LFSR_WIDTH-j-1];
+                state_val[j] = output_mask_state_i[i][LFSR_WIDTH-j-1];
             end
-            output_mask_state[i] = state_val;
+            output_mask_state_i[i] = state_val;
 
             data_val = 0;
             for (j = 0; j < DATA_WIDTH; j = j + 1) begin
-                data_val[j] = output_mask_data[i][DATA_WIDTH-j-1];
+                data_val[j] = output_mask_data_i[i][DATA_WIDTH-j-1];
             end
-            output_mask_data[i] = data_val;
+            output_mask_data_i[i] = data_val;
         end
     end
 
+    for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
+        generate_masks[0 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = lfsr_mask_state_i[i];
+        generate_masks[1 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = lfsr_mask_data_i[i];
+    end
+
+    for (i = 0; i < DATA_WIDTH; i = i + 1) begin
+        generate_masks[2 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = output_mask_state_i[i];
+        generate_masks[3 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH] = output_mask_data_i[i];
+    end
+end
+endfunction
+
+reg [4*MAX_WIDTH*MAX_WIDTH:0] generated_masks = generate_masks(1);
+
+initial begin
+    for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
+        lfsr_mask_state[i] = generated_masks[0 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+        lfsr_mask_data[i] = generated_masks[1 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+    end
+
+    for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
+        output_mask_data[i] = generated_masks[3 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+        output_mask_state[i] = generated_masks[2 * MAX_WIDTH * MAX_WIDTH + (i+1) * MAX_WIDTH -: MAX_WIDTH];
+    end
+
     // for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-    //     $display("%b %b", lfsr_mask_state[i], lfsr_mask_data[i]);
+    //     $display("%d %b %b", i, lfsr_mask_state[i], lfsr_mask_data[i]);
     // end
 end
+
+
 
 // synthesis translate_off
 `define SIMULATION
@@ -370,72 +408,72 @@ genvar n;
 
 generate
 
-if (STYLE_INT == "REDUCTION") begin
+    if (STYLE_INT == "REDUCTION") begin
 
-    // use Verilog reduction operator
-    // fast in iverilog
-    // significantly larger than generated code with ISE (inferred wide XORs may be tripping up optimizer)
-    // slightly smaller than generated code with Quartus
-    // --> better for simulation
+        // use Verilog reduction operator
+        // fast in iverilog
+        // significantly larger than generated code with ISE (inferred wide XORs may be tripping up optimizer)
+        // slightly smaller than generated code with Quartus
+        // --> better for simulation
 
-    for (n = 0; n < LFSR_WIDTH; n = n + 1) begin : loop1
-        assign state_out[n] = ^{(state_in & lfsr_mask_state[n]), (data_in & lfsr_mask_data[n])};
-    end
-    for (n = 0; n < DATA_WIDTH; n = n + 1) begin : loop2
-        assign data_out[n] = ^{(state_in & output_mask_state[n]), (data_in & output_mask_data[n])};
-    end
+        for (n = 0; n < LFSR_WIDTH; n = n + 1) begin : loop1
+            assign state_out[n] = ^{(state_in & lfsr_mask_state[n]), (data_in & lfsr_mask_data[n])};
+        end
+        for (n = 0; n < DATA_WIDTH; n = n + 1) begin : loop2
+            assign data_out[n] = ^{(state_in & output_mask_state[n]), (data_in & output_mask_data[n])};
+        end
 
-end else if (STYLE_INT == "LOOP") begin
+    end else if (STYLE_INT == "LOOP") begin
 
-    // use nested loops
-    // very slow in iverilog
-    // slightly smaller than generated code with ISE
-    // same size as generated code with Quartus
-    // --> better for synthesis
+        // use nested loops
+        // very slow in iverilog
+        // slightly smaller than generated code with ISE
+        // same size as generated code with Quartus
+        // --> better for synthesis
 
-    reg [LFSR_WIDTH-1:0] state_out_reg = 0;
-    reg [DATA_WIDTH-1:0] data_out_reg = 0;
+        reg [LFSR_WIDTH-1:0] state_out_reg = 0;
+        reg [DATA_WIDTH-1:0] data_out_reg = 0;
 
-    assign state_out = state_out_reg;
-    assign data_out = data_out_reg;
+        assign state_out = state_out_reg;
+        assign data_out = data_out_reg;
 
-    always @* begin
-        for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
-            state_out_reg[i] = 0;
-            for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
-                if (lfsr_mask_state[i][j]) begin
-                    state_out_reg[i] = state_out_reg[i] ^ state_in[j];
+        always @* begin
+            for (i = 0; i < LFSR_WIDTH; i = i + 1) begin
+                state_out_reg[i] = 0;
+                for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
+                    if (lfsr_mask_state[i][j]) begin
+                        state_out_reg[i] = state_out_reg[i] ^ state_in[j];
+                    end
+                end
+                for (j = 0; j < DATA_WIDTH; j = j + 1) begin
+                    if (lfsr_mask_data[i][j]) begin
+                        state_out_reg[i] = state_out_reg[i] ^ data_in[j];
+                    end
                 end
             end
-            for (j = 0; j < DATA_WIDTH; j = j + 1) begin
-                if (lfsr_mask_data[i][j]) begin
-                    state_out_reg[i] = state_out_reg[i] ^ data_in[j];
+            for (i = 0; i < DATA_WIDTH; i = i + 1) begin
+                data_out_reg[i] = 0;
+                for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
+                    if (output_mask_state[i][j]) begin
+                        data_out_reg[i] = data_out_reg[i] ^ state_in[j];
+                    end
+                end
+                for (j = 0; j < DATA_WIDTH; j = j + 1) begin
+                    if (output_mask_data[i][j]) begin
+                        data_out_reg[i] = data_out_reg[i] ^ data_in[j];
+                    end
                 end
             end
         end
-        for (i = 0; i < DATA_WIDTH; i = i + 1) begin
-            data_out_reg[i] = 0;
-            for (j = 0; j < LFSR_WIDTH; j = j + 1) begin
-                if (output_mask_state[i][j]) begin
-                    data_out_reg[i] = data_out_reg[i] ^ state_in[j];
-                end
-            end
-            for (j = 0; j < DATA_WIDTH; j = j + 1) begin
-                if (output_mask_data[i][j]) begin
-                    data_out_reg[i] = data_out_reg[i] ^ data_in[j];
-                end
-            end
+
+    end else begin
+
+        initial begin
+            $error("Error: unknown style setting!");
+            $finish;
         end
+
     end
-
-end else begin
-
-    initial begin
-        $error("Error: unknown style setting!");
-        $finish;
-    end
-
-end
 
 endgenerate
 


### PR DESCRIPTION
Some tools like Vivado 2019.1 report  [Synth 8-311] ignoring non-constant assignment in initial block) . This sometimes causes the LFSR module to synthesise empty logic with outputs connected to ground. Proposed refactoring usse a function that produces bit vector of all masks and encapsulates original code. This should enforce all synthesis tools to think of this vector as a statically calculated value. Tested in Vivado 2019.1 - correct LFSR logic synthesized, no more warnings. This probably can also close https://github.com/alexforencich/verilog-ethernet/issues/58